### PR TITLE
Fixed wrong if statement for checkout

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -17,7 +17,6 @@ jobs:
       VERSION: ${{ steps.set_version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        if: github.ref_name == 'develop'
         uses: actions/checkout@v4
         with:
           ref: main


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pipeline.yaml` file. The change removes the conditional `if` statement for the checkout step, ensuring that the code always checks out the `main` branch.

* [`.github/workflows/pipeline.yaml`](diffhunk://#diff-a9fcf81f55b16d4db9d62258b46a56b196b1e20741c9f5fc61728a3578064b98L20): Removed the `if` condition from the `Checkout code` step to always use the `main` branch.