### PR TITLE
Added latest get_version exception

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -25,8 +25,12 @@ jobs:
       - name: Get current version
         id: get_version
         run: |
-          latest=$(git describe --tags --exact-match --abbrev=0)
           develop=$(git describe --tags $(git rev-list --tags --max-count=1)) # gets the latest tag on all branches
+          if [[ ${{ github.ref_name }} == 'main' ]]; then
+            latest=$develop
+          else
+            latest=$(git describe --tags --exact-match --abbrev=0)
+          fi
 
           echo "LATEST=$latest" >> $GITHUB_OUTPUT
           echo "DEVELOP=$develop" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/pipeline.yaml` file. The change improves the way the current version is determined based on the branch name.

* [`.github/workflows/pipeline.yaml`](diffhunk://#diff-a9fcf81f55b16d4db9d62258b46a56b196b1e20741c9f5fc61728a3578064b98L28-R33): Modified the `get_version` job to set `latest` to `develop` if the branch is `main`, otherwise, it uses the previous method to get the latest tag.